### PR TITLE
fix: mouse status is now checked when entering document

### DIFF
--- a/src/components/SplitPane/hooks/callbacks/useHandleDragStart.ts
+++ b/src/components/SplitPane/hooks/callbacks/useHandleDragStart.ts
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react';
 import { BeginDragCallback, ClientPosition } from '../effects/useDragState';
-import { ChildPane } from '../useSplitPaneResize';
-import { SplitPaneHooks, SplitType } from '../..';
+import { SplitPaneHooks } from '../..';
 import { useGetCurrentPaneSizes } from './useGetCurrentPaneSizes';
 
 /**
@@ -10,16 +9,12 @@ import { useGetCurrentPaneSizes } from './useGetCurrentPaneSizes';
 export function useHandleDragStart({
   isReversed,
   hooks,
-  childPanes,
-  split,
   beginDrag,
   setSizes,
   getCurrentPaneSizes,
 }: {
   isReversed: boolean;
-  childPanes: Omit<ChildPane, 'size'>[];
   hooks?: SplitPaneHooks;
-  split: SplitType;
   beginDrag: BeginDragCallback<any>;
   setSizes: React.Dispatch<React.SetStateAction<number[]>>;
   getCurrentPaneSizes: ReturnType<typeof useGetCurrentPaneSizes>;
@@ -31,6 +26,6 @@ export function useHandleDragStart({
       beginDrag(pos, { index: isReversed ? index - 1 : index });
       setSizes(clientSizes);
     },
-    [beginDrag, childPanes, hooks, isReversed, split]
+    [beginDrag, getCurrentPaneSizes, hooks, isReversed, setSizes]
   );
 }

--- a/src/components/SplitPane/hooks/callbacks/useUpdateCollapsedSizes.ts
+++ b/src/components/SplitPane/hooks/callbacks/useUpdateCollapsedSizes.ts
@@ -31,7 +31,6 @@ export function useUpdateCollapsedSizes({
             return movedSizes[idx]; // when collapsed store current size
           }
           if (!isCollapsed && size !== null) {
-            console.log(`uncollapsing index ${idx} with size ${size}`);
             unCollapseSize({ idx, size }); // when un-collapsed clear size
             hooks?.onChange?.(sizes);
             return null;

--- a/src/components/SplitPane/hooks/useSplitPaneResize.ts
+++ b/src/components/SplitPane/hooks/useSplitPaneResize.ts
@@ -172,8 +172,6 @@ export function useSplitPaneResize(options: SplitPaneResizeOptions): SplitPaneRe
     setSizes,
     isReversed,
     hooks,
-    split,
-    childPanes,
     beginDrag,
     getCurrentPaneSizes,
   });


### PR DESCRIPTION
This was an interesting problem to solve, and ended up handling it by simply assuming that if the mouse button is down when entering the document then the user was dragging as it's highly unlikely that a user would press down and then drag into the `document`.

This works pretty well.  If the mouse is up when entering but it was previously dragging then it simply stops the drag and saves the state.