### PR TITLE
fix: Collapse Fixes

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -34,40 +34,46 @@ const CollapseOverlay = styled.div`
 `;
 export interface PaneProps {
   size: number;
-
+  minSize: number;
   split: SplitType;
   className: string;
   isCollapsed: boolean;
   forwardRef: React.Ref<HTMLDivElement>;
   collapseOverlayCss?: React.CSSProperties;
-  isSiblingCollapsed: boolean;
+  collapsedIndices: number[];
   children: React.ReactNode;
   transitionTimeout: number | undefined;
 }
 export const Pane = React.memo(
   ({
     size,
+    minSize,
     isCollapsed,
     collapseOverlayCss = { background: 'rgba(220,220,220, 0.1)' },
     split,
     className,
-    forwardRef,
     children,
-    isSiblingCollapsed,
+    forwardRef,
+    collapsedIndices,
     transitionTimeout,
   }: PaneProps) => {
     const classes = useMergeClasses(['Pane', split, className]);
     const timeout = useMemo(() => transitionTimeout ?? DEFAULT_COLLAPSE_TRANSITION_TIMEOUT, [
       transitionTimeout,
     ]);
-    const [shouldAnimate, setShouldAnimate] = useState<boolean>(isCollapsed || isSiblingCollapsed);
+    const [shouldAnimate, setShouldAnimate] = useState<boolean>(false);
     useEffect(() => {
       if (timeout !== 0) {
         setShouldAnimate(true);
         setTimeout(() => setShouldAnimate(false), 500);
       }
-    }, [setShouldAnimate, isCollapsed, isSiblingCollapsed, timeout]);
+    }, [setShouldAnimate, collapsedIndices, timeout]);
 
+    const minStyle = useMemo(
+      () => (split === 'vertical' ? { minWidth: minSize } : { minHeight: minSize }),
+      [minSize, split]
+    );
+    const wrappedChildren = <div style={minStyle}>{children}</div>;
     return (
       <StyledDiv
         isVertical={split === 'vertical'}
@@ -78,9 +84,9 @@ export const Pane = React.memo(
         timeout={timeout}
       >
         {isCollapsed ? (
-          <CollapseOverlay style={collapseOverlayCss}>{children}</CollapseOverlay>
+          <CollapseOverlay style={collapseOverlayCss}>{wrappedChildren}</CollapseOverlay>
         ) : (
-          children
+          wrappedChildren
         )}
       </StyledDiv>
     );

--- a/src/components/SplitPane/helpers.ts
+++ b/src/components/SplitPane/helpers.ts
@@ -104,6 +104,14 @@ export const convertCollapseSizesToIndices = (sizes?: Nullable<number>[]) =>
   sizes?.reduce((prev, cur, idx) => (cur !== null ? [...prev, idx] : [...prev]), [] as number[]) ??
   [];
 
+export const debounce = (callback: (...args: any[]) => void, wait = 250) => {
+  let timer: any;
+  return (...args: any[]) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => callback(...args), wait);
+  };
+};
+
 const verticalCss = css`
   left: 0;
   right: 0;

--- a/src/components/SplitPane/hooks/callbacks/useCollapseSize.ts
+++ b/src/components/SplitPane/hooks/callbacks/useCollapseSize.ts
@@ -24,16 +24,23 @@ export function useCollapseSize({
       const index = isReversed ? idx - 1 : idx;
       const newSizes = [...movedSizes];
       moveSizes({ sizes: newSizes, index, offset, minSizes, collapsedIndices, collapsedSize });
-      if (collapsedIndices.includes(isReversed ? idx - 1 : idx + 1)) {
-        // this should be a loop, right now only takes care of "left" pane to the current one
-        moveSizes({
-          sizes: newSizes,
-          index: isReversed ? idx - 2 : idx + 1,
-          offset: offset,
-          minSizes,
-          collapsedIndices,
-          collapsedSize,
-        });
+
+      //cascade move to collapsed siblings
+      for (
+        let i = isReversed ? idx : idx + 1;
+        isReversed ? i > 0 : i < movedSizes.length - 1;
+        isReversed ? i-- : i++
+      ) {
+        if (collapsedIndices.includes(i)) {
+          moveSizes({
+            sizes: newSizes,
+            index: isReversed ? i - 2 : i,
+            offset: offset,
+            minSizes,
+            collapsedIndices,
+            collapsedSize,
+          });
+        }
       }
       setMovedSizes(newSizes);
       setSizes(newSizes);

--- a/src/components/SplitPane/hooks/callbacks/useRecalculateSizes.ts
+++ b/src/components/SplitPane/hooks/callbacks/useRecalculateSizes.ts
@@ -1,0 +1,57 @@
+import { getMinSize, moveSizes } from '../../helpers';
+import React, { useCallback } from 'react';
+
+export function useRecalculateSizes({
+  getCurrentPaneSizes,
+  collapsedSize,
+  collapsedIndices,
+  originalMinSizes,
+  minSizes,
+  setMovedSizes,
+  setSizes,
+}: {
+  getCurrentPaneSizes: () => number[];
+  collapsedIndices: number[];
+  collapsedSize: number;
+  originalMinSizes: number | number[] | undefined;
+  minSizes: number[];
+  setMovedSizes: React.Dispatch<React.SetStateAction<number[]>>;
+  setSizes: React.Dispatch<React.SetStateAction<number[]>>;
+}) {
+  return useCallback(() => {
+    const curSizes = getCurrentPaneSizes();
+    const adjustedSizes = curSizes.map((size, idx) => {
+      if (collapsedIndices.includes(idx)) {
+        return collapsedSize;
+      }
+      if (collapsedIndices.includes(idx - 1)) {
+        return size + curSizes[idx - 1] - collapsedSize;
+      }
+      return size;
+    });
+    curSizes.forEach((_size, idx) => {
+      const offset = curSizes[idx] - getMinSize(idx, originalMinSizes);
+      // if offset is negative this means the min size is greater and we need to move this guy
+      if (offset < 0) {
+        moveSizes({
+          collapsedIndices,
+          collapsedSize,
+          sizes: adjustedSizes,
+          index: idx,
+          offset: -offset,
+          minSizes,
+        });
+      }
+    });
+    setMovedSizes(adjustedSizes);
+    setSizes(adjustedSizes);
+  }, [
+    collapsedIndices,
+    collapsedSize,
+    getCurrentPaneSizes,
+    minSizes,
+    originalMinSizes,
+    setMovedSizes,
+    setSizes,
+  ]);
+}

--- a/src/components/SplitPane/hooks/memos/useCollapsedSizes.ts
+++ b/src/components/SplitPane/hooks/memos/useCollapsedSizes.ts
@@ -1,15 +1,18 @@
 import React, { useMemo } from 'react';
+import { CollapseOptions } from '../../../Resizer';
 
 export function useCollapsedSizes({
   collapsedSizes,
   children,
+  collapseOptions,
 }: {
   children: React.ReactChild[];
   collapsedSizes?: Nullable<number>[];
+  collapseOptions?: CollapseOptions;
 }) {
   return useMemo(
     () =>
-      collapsedSizes?.length === children.length
+      collapsedSizes?.length === children.length && collapseOptions !== undefined
         ? collapsedSizes
         : new Array(children.length).fill(null),
     [children, collapsedSizes]

--- a/src/components/SplitPane/hooks/memos/useMinSizes.ts
+++ b/src/components/SplitPane/hooks/memos/useMinSizes.ts
@@ -2,6 +2,9 @@ import { useMemo } from 'react';
 import { DEFAULT_MIN_SIZE, getMinSize } from '../../helpers';
 import { CollapseOptions } from '../../../Resizer';
 
+/**
+ * Returns the current actual minimum size of the panel.  This in some cases means the collapsed size.
+ */
 export function useMinSizes({
   minSizes,
   children,

--- a/src/components/SplitPane/index.tsx
+++ b/src/components/SplitPane/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Pane } from '../Pane';
 import { CollapseOptions, Resizer, ResizerOptions } from '../Resizer';
 import { useSplitPaneResize } from './hooks/useSplitPaneResize';
-import { convertCollapseSizesToIndices, Wrapper } from './helpers';
+import { convertCollapseSizesToIndices, getMinSize, Wrapper } from './helpers';
 import { useMergeClasses } from '../../hooks/useMergeClasses';
 import { useIsCollapseReversed } from './hooks/memos/useIsCollapseReversed';
 import { useToggleCollapse } from './hooks/callbacks/useToggleCollapse';
@@ -84,6 +84,7 @@ export const SplitPane = ({ className = '', direction = 'ltr', ...props }: Split
           isCollapsed={getIsPaneCollapsed(paneIndex)}
           collapsedIndices={collapsedIndices}
           split={props.split}
+          minSize={getMinSize(paneIndex, props.minSizes)}
           className={className}
           transitionTimeout={props.collapseOptions?.collapseTransitionTimeout}
           collapseOverlayCss={props.collapseOptions?.overlayCss}

--- a/src/components/SplitPane/index.tsx
+++ b/src/components/SplitPane/index.tsx
@@ -82,9 +82,7 @@ export const SplitPane = ({ className = '', direction = 'ltr', ...props }: Split
           forwardRef={pane.ref}
           size={pane.size}
           isCollapsed={getIsPaneCollapsed(paneIndex)}
-          isSiblingCollapsed={
-            getIsPaneCollapsed(paneIndex - 1) || getIsPaneCollapsed(paneIndex + 1)
-          }
+          collapsedIndices={collapsedIndices}
           split={props.split}
           className={className}
           transitionTimeout={props.collapseOptions?.collapseTransitionTimeout}

--- a/stories/Collapse.stories.tsx
+++ b/stories/Collapse.stories.tsx
@@ -39,13 +39,12 @@ storiesOf('Collapsable Panes', module)
       backgroundRepeat: 'no-repeat',
       borderRight: '1px solid rgba(0, 0, 0, 0.1)',
     });
-    const minSizes = object('minimum sizes', [50, 50, 50, 50]);
+    const minSizes = object('minimum sizes', [300, 50, 50, 50]);
     const collapseTransition = number('Collapse Transition Speed (ms)', 500);
 
     return (
       <SplitPane
         split="vertical"
-        initialSizes={[340.75, 816.75, 273.75, 251.75]}
         collapseOptions={{
           beforeToggleButton: <Button>{collapseDirection === 'left' ? '⬅' : '➡'}</Button>,
           afterToggleButton: <Button>{collapseDirection === 'left' ? '➡' : '⬅'}</Button>,

--- a/stories/InitialState.stories.tsx
+++ b/stories/InitialState.stories.tsx
@@ -22,7 +22,7 @@ const Button = styled.div`
 `;
 
 storiesOf('Initial States', module)
-  .add('With collapsed Panes', () => {
+  .add('Ltr, First Pane Collapsed', () => {
     const verticalCollapseDirection = select(
       'Vertical Direction',
       { left: 'left', right: 'right' },
@@ -44,14 +44,10 @@ storiesOf('Initial States', module)
     );
 
     return (
-      <VerticalSplitPane collapsedSizes={[140, 500, null]}>
+      <VerticalSplitPane collapsedSizes={[200, null, null]}>
         <div>This is a div</div>
         <div>This is a second div</div>
         <div>This is a third div</div>
-        <VerticalSplitPane collapsedSizes={[]}>
-          <div>one</div>
-          <div>two</div>
-        </VerticalSplitPane>
       </VerticalSplitPane>
     );
   })

--- a/stories/rtl.stories.tsx
+++ b/stories/rtl.stories.tsx
@@ -17,7 +17,7 @@ const Button = styled.div`
   cursor: pointer;
   user-select: none;
   text-align: center;
-  color: lightskyblue;
+  color: white;
   border: 1px silver solid;
 `;
 


### PR DESCRIPTION
Cascades now apply correctly to all siblings.

Minimum sizes now are applied whatever the size of the window is. If the window is resized they are recalculated.

Hidden collapsed panes will not shrink their content past the minimum size but will hide it.