### PR TITLE
Make collapsed panes have flexGrow 0, and add units to resizer flex styles

### DIFF
--- a/src/components/Pane/index.tsx
+++ b/src/components/Pane/index.tsx
@@ -119,7 +119,7 @@ const UnMemoizedPane = ({
       $timeout={timeout}
       className={classes}
       ref={forwardRef}
-      style={{ flexBasis: size }}
+      style={{ flexBasis: size, flexGrow: isCollapsed ? 0 : 1 }}
     >
       <CollapseOverlay $isCollapsed={isCollapsed} $timeout={timeout} style={collapseOverlayCss} />
       <WidthPreserver $isCollapsed={isCollapsed} style={widthPreserverStyle}>

--- a/src/components/Resizer/index.tsx
+++ b/src/components/Resizer/index.tsx
@@ -112,7 +112,7 @@ export const Resizer = ({
   const isTransition = collapseOptions?.buttonTransition !== 'none';
   const collapseButton = collapseOptions ? (
     <ButtonContainer $isVertical={isVertical} $grabberSize={grabberSizeWithUnit} $isLtr={isLtr}>
-      <div style={{ flex: `1 1 ${preButtonFlex}` }} />
+      <div style={{ flex: `1 1 ${preButtonFlex}px` }} />
       <Transition
         in={isTransition ? isHovered : true}
         timeout={isTransition ? collapseOptions.buttonTransitionTimeout : 0}
@@ -126,7 +126,7 @@ export const Resizer = ({
           {isCollapsed ? collapseOptions.afterToggleButton : collapseOptions.beforeToggleButton}
         </ButtonWrapper>
       </Transition>
-      <div style={{ flex: `1 1 ${postButtonFlex}` }} />
+      <div style={{ flex: `1 1 ${postButtonFlex}px` }} />
     </ButtonContainer>
   ) : null;
 

--- a/src/components/SplitPane/hooks/useSplitPaneResize.ts
+++ b/src/components/SplitPane/hooks/useSplitPaneResize.ts
@@ -1,4 +1,5 @@
-import * as React from 'react';
+
++import * as React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { SplitPaneProps, CollapseOptions } from '..';
 import { useDragState, BeginDragCallback } from './effects/useDragState';
@@ -142,7 +143,8 @@ export const useSplitPaneResize = (options: SplitPaneResizeOptions): SplitPaneRe
   }, [dragState, movedSizes, hooks]);
   useEffect(() => {
     hooks?.onCollapse?.(collapsedSizes);
-  }, [collapsedSizes, hooks]);
+    hooks?.onSaveSizes?.(movedSizes)
+  }, [collapsedSizes, movedSizes, hooks]);
   useEffect(() => {
     updateCollapsedSizes(collapsedIndices);
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
1. I noticed that collapsed panes will change sizes on container resize... Which happens quite often if you use multiple nested `<SplitPane />`. As suggested in the issue, there might be something wrong with the width calculation, since an inspection shows the `flex-basis` of children don't add up to the total container size... But for my use case, adding `flexGrow: 0` to collapsed panes solved my problem.
2. Added units to the flex property. As discovered here: https://github.com/b-zurg/react-collapse-pane/issues/60