### PR TITLE
feat: optionally exclude null children

### DIFF
--- a/src/components/SplitPane/hooks/useSplitPaneResize.ts
+++ b/src/components/SplitPane/hooks/useSplitPaneResize.ts
@@ -56,7 +56,11 @@ export const useSplitPaneResize = (options: SplitPaneResizeOptions): SplitPaneRe
     isLtr,
   } = options;
 
-  const children = !Array.isArray(originalChildren) ? [originalChildren] : originalChildren;
+  const allChildren = !Array.isArray(originalChildren) ? [originalChildren] : originalChildren;
+  const children = collapseOptions?.excludeNullChildren
+    ? allChildren.filter(child => child !== null)
+    : allChildren;
+
   // VALUES: const values used throughout the different logic
   const paneRefs = useRef(new Map<string, React.RefObject<HTMLDivElement>>());
 

--- a/src/components/SplitPane/index.tsx
+++ b/src/components/SplitPane/index.tsx
@@ -34,6 +34,7 @@ export interface CollapseOptions {
   collapseTransitionTimeout: number;
   collapsedSize: number;
   overlayCss: React.CSSProperties;
+  excludeNullChildren: boolean;
 }
 export interface ResizerOptions {
   css?: React.CSSProperties;


### PR DESCRIPTION
For our usage, we don't want to render a child if it's `null`. This adds an option to exclude `null` children. I tested with temporary changes to one of the stories. If you'd like, I can add an additional story to make use of the option.