### PR TITLE
feat: Upgrade MUI and remove zurg.dev domain from links

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-collapse-pane.zurg.dev
+b-zurg.github.io

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is intended to be **the** simple, reliable, configurable, and elegant solution to having splittable, draggable and collapsible panes in your React application. 
 
-<a href="https://collapse-pane.zurg.dev" target="_blank"><img src="logo.svg" alt="logo" style="width:100%"/></a>
+<a href="https://storybook-collapse-pane.netlify.app/" target="_blank"><img src="logo.svg" alt="logo" style="width:100%"/></a>
 <p align="center">
   <a href="https://github.com/b-zurg/react-collapse-pane/pulls">
     <img alt="prs welcome" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg">
@@ -26,7 +26,7 @@ This is intended to be **the** simple, reliable, configurable, and elegant solut
   <a href="https://www.npmjs.com/package/react-collapse-pane/v/latest">
     <img alt="npm downloads" src="https://img.shields.io/npm/dw/react-collapse-pane">
   </a>
-  <a href="https://react-collapse-pane.zurg.dev/?path=/story/*">
+  <a href="https://storybook-collapse-pane.netlify.app/?path=/story/*">
     <img alt="storybook" src="https://cdn.jsdelivr.net/gh/storybookjs/brand@master/badge/badge-storybook.svg">
   </a>
   <a href="https://opensource.org/licenses/MIT">
@@ -35,8 +35,8 @@ This is intended to be **the** simple, reliable, configurable, and elegant solut
 
 </p>
 
-## [[click for storybook demo]](https://storybook.collapse-pane.zurg.dev/)
-## [[click for documentation site]](https://collapse-pane.zurg.dev/)
+## [[click for storybook demo]](https://storybook-collapse-pane.netlify.app/)
+## [[click for documentation site]](https://b-zurg.github.io/react-collapse-pane/)
 
 # Getting Started :rocket:
 
@@ -88,11 +88,11 @@ There is no limit to the number of elements you have as children.  The `SplitPan
 
 This library supports all of these things and more! 
 
-For more details check out [the documentation](https://collapse-pane.zurg.dev/)
+For more details check out [the documentation](https://b-zurg.github.io/react-collapse-pane/)
 
 # Documentation
 
-Documentation can be found at https://collapse-pane.zurg.dev 
+Documentation can be found at https://b-zurg.github.io/react-collapse-pane/ 
 
 If you notice an issue then please make an issue or a PR!  All docs are generated from the `docs` folder in the master branch.
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-collapse-pane.zurg.dev
+b-zurg.github.io

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -11,7 +11,7 @@
 - Easy styling and configuration
 
 [GitHub](https://github.com/b-zurg/react-collapse-pane/)
-[Storybook](https://storybook.collapse-pane.zurg.dev/)
+[Storybook](https://storybook-collapse-pane.netlify.app//)
 [Get Started](/?id=react-collapse-pane)
 
 ![color](#2E2E2E)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "name": "react-collapse-pane",
   "repository": "https://github.com/b-zurg/react-collapse-pane",
-  "homepage": "https://collapse-pane.zurg.dev",
+  "homepage": "https://b-zurg.github.io/react-collapse-pane/",
   "bugs": "https://github.com/b-zurg/react-collapse-pane/issues",
   "description": "The splittable, draggable and collapsible react layout library.",
   "author": "Buzurgmehr Arjmandi",

--- a/stories/Collapse.stories.tsx
+++ b/stories/Collapse.stories.tsx
@@ -71,7 +71,7 @@ storiesOf('Collapsable Panes', module)
         >
           <Logo src={logo} className="App-logo" alt="logo" />
           <p>You can collapse and resize these panes!</p>
-          <Link href="https://collapse-pane.zurg.dev" target="_blank" rel="noopener noreferrer">
+          <Link href="https://b-zurg.github.io/react-collapse-pane/" target="_blank" rel="noopener noreferrer">
             <p>Check out the Docs</p>
           </Link>
         </SplitPane>


### PR DESCRIPTION
BREAKING CHANGE: This is a breaking change in terms of dependencies. You must have the latest material ui for now to enable transitions. All other dependencies have been upgraded. Otherwise nothing has changed.